### PR TITLE
Add unpack options to basisu

### DIFF
--- a/basisu_tool.cpp
+++ b/basisu_tool.cpp
@@ -1605,22 +1605,18 @@ static bool unpack_and_validate_ktx2_file(
 					gpu_image& gi = gpu_images[(int)transcoder_tex_fmt][face_index][layer_index][level_index];
 					gi.init(tex_fmt, level_info.m_orig_width, level_info.m_orig_height);
 
-					// skip transcode if we're unpacking rgba only
-					// if (!opts.m_unpack_rgba_only && (opts.m_unpack_level < 0 || level_index == (uint32_t) opts.m_unpack_level))
+					// Fill the buffer with psuedo-random bytes, to help more visibly detect cases where the transcoder fails to write to part of the output.
+					fill_buffer_with_random_bytes(gi.get_ptr(), gi.get_size_in_bytes());
+
+					uint32_t decode_flags = 0;
+
+					if (!dec.transcode_image_level(level_index, layer_index, face_index, gi.get_ptr(), gi.get_total_blocks(), transcoder_tex_fmt, decode_flags))
 					{
-						// Fill the buffer with psuedo-random bytes, to help more visibly detect cases where the transcoder fails to write to part of the output.
-						fill_buffer_with_random_bytes(gi.get_ptr(), gi.get_size_in_bytes());
-
-						uint32_t decode_flags = 0;
-
-						if (!dec.transcode_image_level(level_index, layer_index, face_index, gi.get_ptr(), gi.get_total_blocks(), transcoder_tex_fmt, decode_flags))
-						{
-							error_printf("Failed transcoding image level (%u %u %u %u)!\n", layer_index, level_index, face_index, format_iter);
-							return false;
-						}
-
-						printf("Transcode of layer %u level %u face %u res %ux%u format %s succeeded\n", layer_index, level_index, face_index, level_info.m_orig_width, level_info.m_orig_height, basist::basis_get_format_name(transcoder_tex_fmt));
+						error_printf("Failed transcoding image level (%u %u %u %u)!\n", layer_index, level_index, face_index, format_iter);
+						return false;
 					}
+
+					printf("Transcode of layer %u level %u face %u res %ux%u format %s succeeded\n", layer_index, level_index, face_index, level_info.m_orig_width, level_info.m_orig_height, basist::basis_get_format_name(transcoder_tex_fmt));
 				}
 
 			} // format_iter

--- a/basisu_tool.cpp
+++ b/basisu_tool.cpp
@@ -1629,13 +1629,13 @@ static bool unpack_and_validate_ktx2_file(
 	{
 		// Now write KTX files and unpack them to individual PNG's
 		const bool is_cubemap_array = (dec.get_faces() > 1) && (total_layers > 1);
+		const basist::transcoder_texture_format internal_format = is_etc1s ? basist::transcoder_texture_format::cTFETC2_RGBA : basist::transcoder_texture_format::cTFASTC_4x4_RGBA;
 
 		for (int format_iter = first_format; format_iter < last_format; format_iter++)
 		{
 			const basist::transcoder_texture_format transcoder_tex_fmt = static_cast<basist::transcoder_texture_format>(format_iter);
 
-			if ((opts.m_unpack_rgba_only && transcoder_tex_fmt != basist::transcoder_texture_format::cTFETC2_RGBA) ||
-				basist::basis_transcoder_format_is_uncompressed(transcoder_tex_fmt))
+			if ((opts.m_unpack_rgba_only && transcoder_tex_fmt != internal_format) || basist::basis_transcoder_format_is_uncompressed(transcoder_tex_fmt))
 				continue;
 			if (!basis_is_format_supported(transcoder_tex_fmt, dec.get_format()))
 				continue;
@@ -1722,9 +1722,9 @@ static bool unpack_and_validate_ktx2_file(
 						{
 							std::string rgba_filename;
 							if (gi.size() > 1)
-								rgba_filename = base_filename + string_format("_unpacked_rgba_%s_%u_%04u.png", basist::basis_get_format_name(transcoder_tex_fmt), level_index, face_index, layer_index);
+								rgba_filename = base_filename + string_format("_unpacked_rgba_%u_%u_%04u.png", level_index, face_index, layer_index);
 							else
-								rgba_filename = base_filename + string_format("_unpacked_rgba_%s_%u_%04u.png", basist::basis_get_format_name(transcoder_tex_fmt), face_index, layer_index);
+								rgba_filename = base_filename + string_format("_unpacked_rgba_%u_%04u.png", face_index, layer_index);
 							if (!save_png(rgba_filename, u))
 							{
 								error_printf("Failed writing to PNG file \"%s\"\n", rgba_filename.c_str());
@@ -1781,7 +1781,7 @@ static bool unpack_and_validate_ktx2_file(
 
 								std::string rgba_filename;
 								if (gi.size() > 1)
-									rgba_filename = base_filename + string_format("_unpacked_rgba_%s_%u_%04u.png", basist::basis_get_format_name(transcoder_tex_fmt), level_index, face_index, layer_index);
+									rgba_filename = base_filename + string_format("_unpacked_rgba_%s_%u_%u_%04u.png", basist::basis_get_format_name(transcoder_tex_fmt), level_index, face_index, layer_index);
 								else
 									rgba_filename = base_filename + string_format("_unpacked_rgba_%s_%u_%04u.png", basist::basis_get_format_name(transcoder_tex_fmt), face_index, layer_index);
 								if (!save_png(rgba_filename, u))


### PR DESCRIPTION
We'd like to use basisu to unpack KTX2 files on the backend for generating thumbnails.

To that end, this PR adds two command line flags which restrict the existing "unpack" functionality:
- `unpack_rgba_only`: skip unpacking the various compression formats to PNG, only uncompress one rgba file
- `unpack_level`: instead of unpacking all mipmaps levels, only unpack the single specified level

With these two options we can convert KTX2->PNG on the backend without introducing any new tooling.